### PR TITLE
Correlated informational messages

### DIFF
--- a/src/main/java/nu/ganslandt/util/commlog/CommLog.java
+++ b/src/main/java/nu/ganslandt/util/commlog/CommLog.java
@@ -26,6 +26,13 @@ public interface CommLog {
     void request(String requestName, Object request);
 
     /**
+     * Logs an informational message using the identifier of the preceding request
+     *
+     * @param message The message to log
+     */
+    void info(String message);
+
+    /**
      * Logs an empty response and maps it to a preceding request.
      */
     void response();

--- a/src/main/java/nu/ganslandt/util/commlog/CommLogImpl.java
+++ b/src/main/java/nu/ganslandt/util/commlog/CommLogImpl.java
@@ -214,6 +214,23 @@ public class CommLogImpl implements CommLog, StringerSource {
             return preferredConstructor;
     }
 
+    @Override
+    public void info(String message) {
+        Request request = this.request.get();
+        String uuid;
+        String requestName;
+
+        if (request != null) {
+            uuid = request.getUUID();
+            requestName = request.getRequestName();
+        } else {
+            uuid = "";
+            requestName = "";
+        }
+
+        COMM.info("Info: [{}] {}({})", new Object[]{uuid, requestName, message});
+    }
+
     /**
      * @inheritDoc
      */

--- a/src/main/java/nu/ganslandt/util/commlog/Request.java
+++ b/src/main/java/nu/ganslandt/util/commlog/Request.java
@@ -7,12 +7,22 @@ import java.util.UUID;
  */
 public class Request {
 
+    private static final Request EMPTY_REQUEST = new Request("", "");
+
+    public static Request empty() {
+        return EMPTY_REQUEST;
+    }
+
     private String requestName;
     private String uuid;
 
     public Request(String requestName) {
+        this(requestName, UUID.randomUUID().toString());
+    }
+
+    private Request(String requestName, String uuid) {
         this.requestName = requestName;
-        this.uuid = UUID.randomUUID().toString();
+        this.uuid = uuid;
     }
 
     public String getRequestName() {
@@ -22,5 +32,4 @@ public class Request {
     public String getUUID() {
         return uuid;
     }
-
 }

--- a/src/test/java/nu/ganslandt/util/commlog/CommLogTest.java
+++ b/src/test/java/nu/ganslandt/util/commlog/CommLogTest.java
@@ -300,6 +300,17 @@ public class CommLogTest {
         assertTrue(!string.contains("java.lang.StackOverflowError"));
     }
 
+    @Test
+    public void testResponseWithoutRequest_logsWithoutExceptions() {
+        commLog.response();
+        commLog.response(new TestClass());
+        commLog.response("Hello There");
+
+        commLog.info("yes");
+
+        commLog.error("foobar");
+    }
+
     private static class TestClass {
         private Object data;
 


### PR DESCRIPTION
I've added functionality for logging an informational message (`info()`) which is correlated to the previous request logged using `request()`.

*Sidenote:*
How can I refactor to avoid the duplicate `if`-statements?