### PR TITLE
Don't print static fields

### DIFF
--- a/src/main/java/nu/ganslandt/util/commlog/ReflectingPropertyStringer.java
+++ b/src/main/java/nu/ganslandt/util/commlog/ReflectingPropertyStringer.java
@@ -29,8 +29,9 @@ public class ReflectingPropertyStringer extends Stringer {
             for (Field f : clazz.getDeclaredFields()) {
                 String value;
 
-                if (Modifier.isTransient(f.getModifiers()))
+                if (Modifier.isTransient(f.getModifiers()) || Modifier.isStatic(f.getModifiers())) {
                     continue;
+                }
 
                 try {
                     f.setAccessible(true);


### PR DESCRIPTION
In this pull request, I modify the `ReflectingPropertyStringer` so that it doesn't print `static` fields. `static` fields are usually constants which we don't want to print in the logs.